### PR TITLE
Update mpl.xsh

### DIFF
--- a/xontrib_kitty/mpl.xsh
+++ b/xontrib_kitty/mpl.xsh
@@ -3,8 +3,8 @@ import sys
 from io import BytesIO
 
 from xonsh.tools import unthreadable
-from xonsh.lazyasd import lazyobject
-from xonsh import lazyimps
+from xonsh.lib.lazyasd import lazyobject
+from xonsh.lib import lazyimps
 
 
 __all__ = ()


### PR DESCRIPTION
Fixes: 
/home/admin/.xonsh_3_13_1/lib/python3.13/site-packages/xontrib_kitty/mpl.xsh:6: DeprecationWarning: Use `xonsh.lib.lazyasd` instead of `xonsh.lazyasd`.
  from xonsh.lazyasd import lazyobject
/home/admin/.xonsh_3_13_1/lib/python3.13/site-packages/xontrib_kitty/mpl.xsh:7: DeprecationWarning: Use `xonsh.lib.lazyimps` instead of `xonsh.lazyimps`.
  from xonsh import lazyimps